### PR TITLE
Fix #62: harden assignments allowlist guard (CSV header, issue-body injection, forged assigned_by)

### DIFF
--- a/.github/workflows/gha-validate-assignments.yml
+++ b/.github/workflows/gha-validate-assignments.yml
@@ -51,14 +51,18 @@ jobs:
       if: steps.validate.outputs.removed_count != '' && steps.validate.outputs.removed_count != '0'
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Passed via env (not inline ${{ }}) so they're shell data, never code.
+        TRIGGER_SHA: ${{ github.sha }}
+        TRIGGER_ACTOR: ${{ github.actor }}
       run: |
         gh label create assignment-guard --color FBCA04 --force >/dev/null 2>&1 || true
-        details=$(python3 -c "import json; [print('- ' + r['file'] + ' qid=' + r['question_id'] + ' assignee=' + r['assignee']) for r in json.load(open('removed-assignments.json'))]")
-        body=$(printf 'The assignment guard auto-reverted row(s) whose assignee is not in the ASSIGNEES allowlist.\n\n**Removed:**\n%s\n\nTriggered by commit %s (actor: @%s).\nReview and, if the person should be allowed, add them to `ASSIGNEES` in `scripts/assignments.py`.' "$details" "${{ github.sha }}" "${{ github.actor }}")
+        # Body is rendered in Python (format_issue_body) so attacker-controlled
+        # assignee/qid text can't inject markdown into the issue.
+        python3 scripts/validate_assignments.py --render-issue-body > issue-body.md
         existing=$(gh issue list --label assignment-guard --state open --json number --jq '.[0].number')
         if [ -n "$existing" ]; then
-          gh issue comment "$existing" --body "$body"
+          gh issue comment "$existing" --body-file issue-body.md
         else
           gh issue create --title "Off-allowlist assignee auto-reverted" \
-            --label assignment-guard --assignee rtanglao --body "$body"
+            --label assignment-guard --assignee rtanglao --body-file issue-body.md
         fi

--- a/scripts/assignments.py
+++ b/scripts/assignments.py
@@ -50,7 +50,9 @@ def load_assignments(path):
     if not path or not os.path.exists(path):
         return {}
     result = {}
-    with open(path, newline='', encoding='utf-8') as f:
+    # utf-8-sig strips a leading BOM so the 'question_id' header lookup works
+    # even if an editor saved the CSV with one (see validate_assignments.py).
+    with open(path, newline='', encoding='utf-8-sig') as f:
         reader = csv.DictReader(f)
         for row in reader:
             qid_raw = (row.get('question_id') or '').strip()

--- a/scripts/test_validate_assignments.py
+++ b/scripts/test_validate_assignments.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Tests for the assignments allowlist guard's CSV-header robustness.
+
+Covers the Finding #1 regression: a BOM or non-canonical header must NOT cause
+the guard to wipe legitimate rows or wave through off-allowlist ones.
+
+Run from the repo root:  uv run scripts/test_validate_assignments.py
+"""
+import os
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import validate_assignments as va
+from assignments import load_assignments
+
+ALLOW = ['rtanglao', 'wsmwk']
+HEADER = 'question_id,assignee,assigned_at,assigned_by'
+
+
+def run_guard(csv_text):
+    """Write csv_text to a temp file, run main() against it, return
+    (file_contents_after, removed_list)."""
+    with tempfile.TemporaryDirectory() as d:
+        path = os.path.join(d, 'a.csv')
+        # csv_text may include a BOM; write bytes verbatim.
+        with open(path, 'wb') as f:
+            f.write(csv_text.encode('utf-8') if isinstance(csv_text, str) else csv_text)
+
+        removed_capture = []
+        with mock.patch.object(va, 'ASSIGNEES', ALLOW), \
+             mock.patch.object(va, 'CSV_PATHS', [path]), \
+             mock.patch.object(va, 'emit', lambda removed: removed_capture.extend(removed)), \
+             mock.patch.dict(os.environ, {}, clear=False):
+            # emit writes removed-assignments.json into cwd; do it in the tempdir.
+            cwd = os.getcwd()
+            os.chdir(d)
+            try:
+                va.main()
+            finally:
+                os.chdir(cwd)
+        with open(path, encoding='utf-8-sig') as f:
+            after = f.read()
+        return after, removed_capture
+
+
+class HeaderRobustness(unittest.TestCase):
+    def test_canonical_keeps_allowlisted_removes_offlist(self):
+        csv_text = (f'{HEADER}\n'
+                    '111,rtanglao,2026-01-01T00:00:00Z,rtanglao\n'
+                    '222,attacker,2026-01-01T00:00:00Z,attacker\n')
+        after, removed = run_guard(csv_text)
+        self.assertIn('111,rtanglao', after)        # legit kept
+        self.assertNotIn('attacker', after)          # off-allowlist removed
+        self.assertEqual([r['assignee'] for r in removed], ['attacker'])
+
+    def test_bom_does_not_wipe_legit_rows(self):
+        # The bug: a BOM made question_id lookups fail, wiping every row.
+        csv_text = ('﻿' + f'{HEADER}\n'
+                    '111,rtanglao,2026-01-01T00:00:00Z,rtanglao\n')
+        after, removed = run_guard(csv_text)
+        self.assertIn('111,rtanglao', after)         # NOT wiped
+        self.assertEqual(removed, [])                # no false "off-allowlist"
+
+    def test_trailing_space_header_left_untouched(self):
+        csv_text = ('question_id ,assignee,assigned_at,assigned_by\n'
+                    '111,rtanglao,2026-01-01T00:00:00Z,rtanglao\n')
+        after, removed = run_guard(csv_text)
+        self.assertIn('111,rtanglao', after)         # untouched, not wiped
+        self.assertEqual(removed, [])
+
+    def test_wrong_case_header_left_untouched_not_waved_through(self):
+        # Off-allowlist row under a wrong-case header: must not be silently kept
+        # as "validated". We leave the file untouched for a human to fix.
+        csv_text = ('Question_ID,Assignee,assigned_at,assigned_by\n'
+                    '222,attacker,2026-01-01T00:00:00Z,attacker\n')
+        after, removed = run_guard(csv_text)
+        # File untouched (no rewrite); removed stays empty because we bailed.
+        self.assertIn('222,attacker', after)
+        self.assertEqual(removed, [])
+
+    def test_load_assignments_handles_bom(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'a.csv')
+            with open(path, 'w', encoding='utf-8') as f:
+                f.write('﻿' + f'{HEADER}\n111,rtanglao,2026-01-01T00:00:00Z,rtanglao\n')
+            loaded = load_assignments(path)
+            self.assertEqual(loaded.get(111, {}).get('assignee'), 'rtanglao')
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/scripts/test_validate_assignments.py
+++ b/scripts/test_validate_assignments.py
@@ -81,6 +81,51 @@ class HeaderRobustness(unittest.TestCase):
         self.assertIn('222,attacker', after)
         self.assertEqual(removed, [])
 
+    def test_forged_assigned_by_blanked_row_kept(self):
+        # Off-allowlist assigned_by is forged attribution: blank it, keep claim.
+        csv_text = (f'{HEADER}\n'
+                    '111,rtanglao,2026-01-01T00:00:00Z,attacker\n')
+        after, removed = run_guard(csv_text)
+        self.assertIn('111,rtanglao', after)         # claim preserved
+        self.assertNotIn('attacker', after)          # forged attribution gone
+        self.assertTrue(after.rstrip().endswith('111,rtanglao,2026-01-01T00:00:00Z,'))
+        self.assertEqual(removed, [])                # not a removal -> no issue
+
+    def test_legit_assigned_by_preserved(self):
+        csv_text = (f'{HEADER}\n'
+                    '111,rtanglao,2026-01-01T00:00:00Z,rtanglao\n')
+        after, _ = run_guard(csv_text)
+        self.assertIn('111,rtanglao,2026-01-01T00:00:00Z,rtanglao', after)
+
+
+class IssueBodySafety(unittest.TestCase):
+    def test_markdown_injection_neutralized(self):
+        removed = [{
+            'file': 'UNANSWERED_QUESTIONS/desktop-assignments.csv',
+            'question_id': '999',
+            # Attacker payload: mention, image, fence-breakout attempt, newline.
+            'assignee': '@everyone ![x](http://evil/i)\n```\n## injected',
+        }]
+        body = va.format_issue_body(removed, sha='abc123', actor='pusher')
+        lines = body.split('\n')
+        # Exactly one fenced block: precisely two lines that ARE a bare fence.
+        fences = [i for i, l in enumerate(lines) if l == '```']
+        self.assertEqual(len(fences), 2)
+        # Payload collapsed to a single line between the fences, starting with
+        # the file path -- so its embedded ``` is mid-line and can't close the
+        # block, and the @mention/image markdown stays inert inside code.
+        inner = lines[fences[0] + 1:fences[1]]
+        self.assertEqual(len(inner), 1)
+        self.assertTrue(inner[0].startswith('UNANSWERED_QUESTIONS/'))
+        self.assertIn('## injected', inner[0])       # stayed inside the block
+        self.assertIn('@everyone', inner[0])         # preserved verbatim as data
+        self.assertIn('actor: @pusher', body)
+
+    def test_empty_removed_renders_none(self):
+        body = va.format_issue_body([], sha='', actor='')
+        self.assertIn('(none)', body)
+        self.assertEqual(body.count('```'), 2)
+
     def test_load_assignments_handles_bom(self):
         with tempfile.TemporaryDirectory() as d:
             path = os.path.join(d, 'a.csv')

--- a/scripts/validate_assignments.py
+++ b/scripts/validate_assignments.py
@@ -41,6 +41,33 @@ def emit(removed):
         json.dump(removed, f, indent=2)
 
 
+def format_issue_body(removed, sha='', actor=''):
+    """Render the notification-issue body.
+
+    The removed rows carry attacker-controlled assignee/question_id text (an
+    off-allowlist row can hold anything), so it is emitted inside a fenced code
+    block with line breaks stripped -- inside a code block GitHub renders no
+    @-mentions, links or images, and because every line starts with the file
+    path a stray ``` in a value can't close the fence. `sha`/`actor` come from
+    GitHub (trusted) but are cleaned the same way for good measure.
+    """
+    def clean(s):
+        return str(s if s is not None else '').replace('\r', ' ').replace('\n', ' ')
+
+    lines = [f"{clean(r.get('file'))} qid={clean(r.get('question_id'))} "
+             f"assignee={clean(r.get('assignee'))}" for r in removed]
+    block = '\n'.join(lines) if lines else '(none)'
+    return (
+        'The assignment guard auto-reverted row(s) whose assignee is not in '
+        'the ASSIGNEES allowlist.\n\n'
+        '**Removed:**\n'
+        f'```\n{block}\n```\n\n'
+        f'Triggered by commit {clean(sha)} (actor: @{clean(actor)}).\n'
+        'Review and, if the person should be allowed, add them to '
+        '`ASSIGNEES` in `scripts/assignments.py`.'
+    )
+
+
 def main():
     allow = {a.lower() for a in ASSIGNEES}  # GitHub logins are case-insensitive
 
@@ -77,6 +104,7 @@ def main():
         kept = []
         seen = set()
         dropped_dupes = 0
+        blanked_by = 0
         # Walk in reverse so the LAST row for a question_id wins on dedupe.
         for row in reversed(rows):
             assignee = (row.get('assignee') or '').strip()
@@ -92,10 +120,17 @@ def main():
                 dropped_dupes += 1          # benign duplicate cleanup; not a violation
                 continue
             seen.add(qid)
+            # assigned_by should be the (allowlisted) claimer. A non-allowlist
+            # value is forged attribution: keep the legitimate claim but blank
+            # the bogus metadata rather than dropping the whole row.
+            assigned_by = (row.get('assigned_by') or '').strip()
+            if assigned_by and assigned_by.lower() not in allow:
+                row['assigned_by'] = ''
+                blanked_by += 1
             kept.append(row)
         kept.reverse()
 
-        if len(kept) != len(rows):
+        if len(kept) != len(rows) or blanked_by:
             try:
                 with open(path, 'w', newline='', encoding='utf-8') as f:
                     writer = csv.DictWriter(f, fieldnames=fieldnames)
@@ -105,7 +140,8 @@ def main():
                 print(f'ERROR writing {path}: {e}', file=sys.stderr)
                 sys.exit(1)
             print(f'{path}: removed {len(rows) - len(kept)} row(s) '
-                  f'(off-allowlist/malformed; {dropped_dupes} duplicate)')
+                  f'(off-allowlist/malformed; {dropped_dupes} duplicate; '
+                  f'{blanked_by} forged assigned_by blanked)')
 
     for r in removed:
         print(f"Removed: {r['file']} qid={r['question_id']} assignee={r['assignee']}")
@@ -116,4 +152,14 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    if len(sys.argv) > 1 and sys.argv[1] == '--render-issue-body':
+        # Used by the workflow's notify step: read the removed rows recorded by
+        # the validation run and print a markdown-safe issue body to stdout.
+        with open('removed-assignments.json', encoding='utf-8') as f:
+            sys.stdout.write(format_issue_body(
+                json.load(f),
+                os.environ.get('TRIGGER_SHA', ''),
+                os.environ.get('TRIGGER_ACTOR', ''),
+            ))
+    else:
+        main()

--- a/scripts/validate_assignments.py
+++ b/scripts/validate_assignments.py
@@ -54,12 +54,24 @@ def main():
         if not os.path.exists(path):
             continue
         try:
-            with open(path, newline='', encoding='utf-8') as f:
+            # utf-8-sig strips a leading BOM so the first header stays
+            # 'question_id' rather than '﻿question_id'.
+            with open(path, newline='', encoding='utf-8-sig') as f:
                 reader = csv.DictReader(f)
                 fieldnames = reader.fieldnames or FIELDNAMES
                 rows = list(reader)
         except (OSError, csv.Error) as e:
             print(f'ERROR reading {path}: {e}; leaving it untouched.', file=sys.stderr)
+            continue
+
+        # If the header isn't canonical (e.g. trailing space, wrong case), the
+        # row.get('question_id'/'assignee') lookups below silently return None.
+        # That would make us either wipe every legitimate row (qid='' fails
+        # isdigit) or wave through unchecked rows (assignee=''). Neither is safe,
+        # so leave the file untouched and let a human fix the header.
+        if 'question_id' not in fieldnames or 'assignee' not in fieldnames:
+            print(f'WARNING: {path} has a non-canonical header {fieldnames!r}; '
+                  f'leaving it untouched.', file=sys.stderr)
             continue
 
         kept = []


### PR DESCRIPTION
Resolves the three live findings from the focused security review in #62. All server-side robustness/integrity; no behavior change on the happy path.

## Finding #1 — MEDIUM: non-canonical CSV header breaks the allowlist guard
`validate_assignments.py` (and `load_assignments`) read the CSV as `utf-8`, so a UTF-8 BOM or an altered first header (trailing space, wrong case) made `row.get('question_id')` return `None`. That either **wiped every legitimate row** (qid fails `isdigit`) and filed a false "off-allowlist" issue naming real users, or waved unchecked rows through.

- Read both with `utf-8-sig` (strips a leading BOM).
- If the parsed header lacks canonical `question_id`/`assignee`, **leave the file untouched** (fail-safe) instead of rewriting.

## Finding #2 — LOW: markdown injection into the notification issue body
The notify step interpolated attacker-controlled removed-row `assignee`/`question_id` text straight into the `gh issue` markdown body. (Confirmed *not* shell injection.) Worst case: `@mention` pings, phishing links, tracking images.

- Body is now rendered by `format_issue_body()` in Python and passed via `--body-file`: removed rows go inside a fenced code block with newlines stripped, so markdown stays inert and an embedded ``` can't close the fence.
- `github.sha`/`github.actor` are passed through `env` (shell data) rather than inline `${{ }}`.

## Finding #3 — LOW: `assigned_by` / `assigned_at` never validated
The guard checked only `assignee` + `question_id`. A kept row's `assigned_by` is now validated against the allowlist; a forged (off-allowlist) value is blanked while the legitimate claim is preserved.

## Tests
New `scripts/test_validate_assignments.py` (9 tests, stdlib `unittest`): BOM / trailing-space / wrong-case headers, canonical keep-remove, BOM in `load_assignments`, forged-vs-legit `assigned_by`, and markdown-injection neutralization. Run with `uv run scripts/test_validate_assignments.py`.

## Verified safe (no change needed) — from the same review
Assignee attribute escaping (false positive: `html.escape` defaults to `quote=True`); the historical `innerHTML` token-theft XSS (already fixed via DOM API + `isValidAssignee`); token handling (`localStorage`-only, `Authorization` header to `api.github.com`, `textContent` messages); workflow trigger/permissions/no-retrigger loop; optimistic-locking races.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
